### PR TITLE
SOLR-17050: Save models compacted

### DIFF
--- a/solr/core/src/java/org/apache/solr/rest/ManagedResourceStorage.java
+++ b/solr/core/src/java/org/apache/solr/rest/ManagedResourceStorage.java
@@ -426,6 +426,14 @@ public abstract class ManagedResourceStorage {
     }
 
     /**
+     * @param indentSize The number of space characters to use as an indent (default 2). 0=newlines   but no spaces, -1=no indent at all.
+     */
+    public JsonStorage(StorageIO storageIO, SolrResourceLoader loader, int indentSize) {
+      super(storageIO, loader);
+      this.indentSize = indentSize;
+    }
+
+    /**
      * Determines the relative path (from the storage root) for the given resource. In this case, it
      * returns a file named with the .json extension.
      */
@@ -441,7 +449,7 @@ public abstract class ManagedResourceStorage {
 
     @Override
     public void store(String resourceId, Object toStore) throws IOException {
-      String json = toJSONString(toStore);
+      String json = toJSONString(toStore, indentSize);
       String storedResourceId = getStoredResourceId(resourceId);
       OutputStreamWriter writer = null;
       try {
@@ -468,7 +476,7 @@ public abstract class ManagedResourceStorage {
 
   protected StorageIO storageIO;
   protected SolrResourceLoader loader;
-
+  protected int indentSize = 2;
   protected ManagedResourceStorage(StorageIO storageIO, SolrResourceLoader loader) {
     this.storageIO = storageIO;
     this.loader = loader;

--- a/solr/core/src/test/org/apache/solr/util/TestUtils.java
+++ b/solr/core/src/test/org/apache/solr/util/TestUtils.java
@@ -294,4 +294,21 @@ public class TestUtils extends SolrTestCaseJ4 {
     assertEquals(
         2L, Utils.getObjectByPath(sink, true, List.of(DEFAULTS, COLLECTION_PROP, NRT_REPLICAS)));
   }
+
+  @SuppressWarnings({"unchecked"})
+  public void testToJson() {
+    Map<String, Object> object =
+            (Map<String, Object>) Utils.fromJSONString("{k2:v2, k1: {a:b, p:r, k21:{xx:yy}}}");
+
+    assertEquals("{\"k2\":\"v2\",\"k1\":{\"a\":\"b\",\"p\":\"r\",\"k21\":{\"xx\":\"yy\"}}}",new String(Utils.toJSON(object,-1)));
+    String formatedJson =
+            "{\n" +
+                    "  \"k2\":\"v2\",\n" +
+                    "  \"k1\":{\n"+
+                    "    \"a\":\"b\",\n" +
+                    "    \"p\":\"r\",\n" +
+                    "    \"k21\":{\"xx\":\"yy\"}}}";
+
+    assertEquals(formatedJson,new String(Utils.toJSON(object)));
+  }
 }

--- a/solr/modules/ltr/src/java/org/apache/solr/ltr/store/rest/ManagedModelStore.java
+++ b/solr/modules/ltr/src/java/org/apache/solr/ltr/store/rest/ManagedModelStore.java
@@ -93,6 +93,12 @@ public class ManagedModelStore extends ManagedResource
     store = new ModelStore();
   }
 
+  @Override
+  protected ManagedResourceStorage createStorage(
+      ManagedResourceStorage.StorageIO storageIO, SolrResourceLoader loader) throws SolrException {
+    return new ManagedResourceStorage.JsonStorage(storageIO, loader, -1);
+  }
+
   public void setManagedFeatureStore(ManagedFeatureStore managedFeatureStore) {
     log.info("INIT model store");
     this.managedFeatureStore = managedFeatureStore;

--- a/solr/solrj/src/java/org/apache/solr/common/util/Utils.java
+++ b/solr/solrj/src/java/org/apache/solr/common/util/Utils.java
@@ -221,6 +221,22 @@ public class Utils {
     return toUTF8(out);
   }
 
+  /**
+   * @param indentSize The number of space characters to use as an indent (default 2). 0=newlines   but no spaces, -1=no indent at all.
+   */
+  public static byte[] toJSON(Object o, int indentSize) {
+    if (o == null) return new byte[0];
+    CharArr out = new CharArr();
+    new JSONWriter(out, indentSize).write(o); // indentation by default
+    return toUTF8(out);
+  }
+  
+  /**
+   * @param indentSize The number of space characters to use as an indent (default 2). 0=newlines   but no spaces, -1=no indent at all.
+   */
+  public static String toJSONString(Object o, int indentSize) {
+    return new String(toJSON(o, indentSize), StandardCharsets.UTF_8);
+  }
   public static String toJSONString(Object o) {
     return new String(toJSON(o), StandardCharsets.UTF_8);
   }


### PR DESCRIPTION
This pull request introduces changes to the `ManagedResourceStorage` class to support customizable JSON indentation and updates related methods and tests accordingly. The most important changes include adding a new constructor to `JsonStorage`, modifying the `store` method to use the new indentation parameter, and updating utility methods to handle indentation.

Enhancements to JSON storage:

* [`solr/core/src/java/org/apache/solr/rest/ManagedResourceStorage.java`](diffhunk://#diff-d1e0c208ddaa18f0408f72ff7b608685c98464453fd5e526599adcde6a802437R428-R435): Added a new constructor to `JsonStorage` that accepts an `indentSize` parameter to control JSON indentation.
* [`solr/core/src/java/org/apache/solr/rest/ManagedResourceStorage.java`](diffhunk://#diff-d1e0c208ddaa18f0408f72ff7b608685c98464453fd5e526599adcde6a802437L444-R452): Modified the `store` method to use the new `indentSize` parameter when converting objects to JSON.
* [`solr/core/src/java/org/apache/solr/rest/ManagedResourceStorage.java`](diffhunk://#diff-d1e0c208ddaa18f0408f72ff7b608685c98464453fd5e526599adcde6a802437L471-R479): Introduced a new `indentSize` field with a default value of 2 and updated the existing constructor.

Updates to utility methods:

* [`solr/solrj/src/java/org/apache/solr/common/util/Utils.java`](diffhunk://#diff-75c317394cc907382b12ddc266fe45f9eac050e5d4a4f88ef5ffc7112b571098R224-R239): Added overloaded `toJSON` and `toJSONString` methods that accept an `indentSize` parameter to control JSON formatting.

Test enhancements:

* [`solr/core/src/test/org/apache/solr/util/TestUtils.java`](diffhunk://#diff-5d337608a0f3de3c06223ca794764f0b71a63efe49211b628cce08707f390268R297-R313): Added a new test method `testToJson` to verify the JSON formatting with different indentation levels.